### PR TITLE
Fix in linear sieve

### DIFF
--- a/spcppl/numbers/linearSieve.hpp
+++ b/spcppl/numbers/linearSieve.hpp
@@ -14,7 +14,7 @@ std::vector<int> linearSieve(int maxN) {
 			primes.push_back(i);
 		}
 		for (int prime: primes) {
-			if (i * prime > maxN) {
+			if (prime > leastPrimes[i] or i * prime > maxN) {
 				break;
 			}
 			leastPrimes[i * prime] = prime;


### PR DESCRIPTION
Adding additional check to avoid repetitive writes on leastPrimes[i]. This is essential for linear time complexity.